### PR TITLE
Update `pytest-argus-server` to use Argus 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,4 +25,4 @@ jobs:
         run: pip install tox
 
       - name: Test
-        run: tox -e py
+        run: tox -e py -- --verbose

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ take requests.  It returns the base URL of the running API:
 .. code-block:: python
 
     def test_url_should_be_as_expected(argus_api_url):
-        assert argus_api_url == "http://localhost:8000/api/v2/"
+        assert argus_api_url == "http://127.0.0.1:8000/api/v2/"
 
 
 ``argus_source_system_token``

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ By default, this plugin will run the *latest available* Argus server Docker
 image.  The actually deployed version can be controlled by adding the
 ``--argus-version`` command line option to pytest::
 
-  pytest --argus-version=1.30.0 tests/
+  pytest --argus-version=2.7.0 tests/
 
 Provided fixtures
 +++++++++++++++++

--- a/src/pytest_argus_server/docker/ci_settings.py
+++ b/src/pytest_argus_server/docker/ci_settings.py
@@ -1,6 +1,6 @@
 """Site settings for running argus server in an integration test harness"""
 
-from argus.site.settings.backend import *
+from argus.site.settings.prod import *
 
 # Allow all hosts, since all requests will typically come from outside the container
 ALLOWED_HOSTS = ["*"]

--- a/src/pytest_argus_server/docker/docker-compose.yml
+++ b/src/pytest_argus_server/docker/docker-compose.yml
@@ -9,14 +9,11 @@ services:
       - "8000:8000"
     depends_on:
       - postgres
-      - redis
     environment:
       - SECRET_KEY=xahQuuWaip1Ookeegaibo6yoj5ij8shok8Eg7eiyeBoo9AaQu5b
       - TIME_ZONE=Europe/Oslo
       - DATABASE_URL=postgresql://argus:argus@postgres/argus
-      - ARGUS_REDIS_SERVER=redis
-      - ARGUS_FRONTEND_URL=http://localhost:3000  # fake it till you make it  #maybe not need this
-      - ARGUS_COOKIE_DOMAIN=localhost   # maybe not need this
+      - ARGUS_FRONTEND_URL=http://localhost:3000
       - STATIC_ROOT=static/
       - ARGUS_SEND_NOTIFICATIONS=0
       - EMAIL_HOST=localhost
@@ -28,6 +25,3 @@ services:
       - POSTGRES_USER=argus
       - POSTGRES_PASSWORD=argus
       - POSTGRES_DB=argus
-
-  redis:
-    image: "redis:latest"

--- a/src/pytest_argus_server/plugin.py
+++ b/src/pytest_argus_server/plugin.py
@@ -71,7 +71,7 @@ def argus_api_url(wait_for_argus_api):
     container.execute(["django-admin", "initial_setup"])
 
     service = container.network_info[0]
-    argus_base_url = f"http://localhost:{service.host_port}/api/v2/"
+    argus_base_url = f"http://127.0.0.1:{service.host_port}/api/v2/"
     return argus_base_url
 
 

--- a/src/pytest_argus_server/plugin.py
+++ b/src/pytest_argus_server/plugin.py
@@ -83,7 +83,7 @@ def wait_for_argus_api(argus_version, session_scoped_container_getter):
     object representing the API container instance
     """
     request_session = requests.Session()
-    retries = Retry(total=5, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504])
+    retries = Retry(total=10, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
     request_session.mount("http://", HTTPAdapter(max_retries=retries))
 
     container = session_scoped_container_getter.get("argus_api")

--- a/tests/test_argus_server.py
+++ b/tests/test_argus_server.py
@@ -4,11 +4,11 @@ def test_version_fixture(pytester):
     # create a temporary pytest test module
     pytester.makepyfile("""
         def test_sth(argus_version):
-            assert argus_version == "1.33.0"
+            assert argus_version == "2.7.0"
     """)
 
     # run pytest with the following cmd args
-    result = pytester.runpytest("--argus-version=1.33.0", "-v")
+    result = pytester.runpytest("--argus-version=2.7.0", "-v")
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(
@@ -47,7 +47,7 @@ def test_argus_api_url_fixture_should_return_expected_url(pytester):
 
     # run pytest with the following cmd args
     result = pytester.runpytest(
-        "--argus-version=1.30.0",  # Because 1.33 (latest) is broken
+        "--argus-version=2.7.0",
         "-v",
     )
 
@@ -82,7 +82,7 @@ def test_argus_token_should_give_api_access(pytester):
 
     # run pytest with the following cmd args
     result = pytester.runpytest(
-        "--argus-version=1.30.0",  # Because 1.33 (latest) is broken
+        "--argus-version=2.7.0",
         "-v",
     )
 

--- a/tests/test_argus_server.py
+++ b/tests/test_argus_server.py
@@ -42,7 +42,7 @@ def test_argus_api_url_fixture_should_return_expected_url(pytester):
     # create a temporary pytest test module
     pytester.makepyfile("""
         def test_sth(argus_api_url):
-            assert argus_api_url == "http://localhost:8000/api/v2/"
+            assert argus_api_url == "http://127.0.0.1:8000/api/v2/"
     """)
 
     # run pytest with the following cmd args


### PR DESCRIPTION
Argus version 1 was obsoleted a long time ago by now, it's time to update this pytest plugin to use the latest available release version.